### PR TITLE
Fix syntax highlighting

### DIFF
--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -51,7 +51,7 @@ ripgrep = { pkg-path = "ripgrep" }
 pip = { pkg-path = "python310Packages.pip" }
 ```
 or
-```
+```toml
 [install.ripgrep]
 pkg-path = "ripgrep"
 


### PR DESCRIPTION
This toml block was oddly unstyled on the documentation site: https://flox.dev/docs/reference/command-reference/manifest.toml/#install

![2024-11-02 at 14 00 29](https://github.com/user-attachments/assets/2b9c245c-bcfc-4b76-9f8a-c43e0ab98413)
